### PR TITLE
Fix transpose codec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          java-version: '8'
+          java-version: '22'
           distribution: 'temurin'
           cache: maven
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu, windows, macos ]
+      fail-fast: false
     runs-on: ${{ matrix.os }}-latest
     defaults:
       run:

--- a/pom.xml
+++ b/pom.xml
@@ -78,4 +78,7 @@
         </repository>
     </repositories>
 
+    <build>
+        <testSourceDirectory>src/test/java/dev/zarr/zarrjava</testSourceDirectory>
+    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -68,12 +68,6 @@
             <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>dev.zarr.zarrjava</groupId>
-            <artifactId>zarr-java</artifactId>
-            <version>0.0.1-SNAPSHOT</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <repositories>

--- a/src/main/java/dev/zarr/zarrjava/utils/Utils.java
+++ b/src/main/java/dev/zarr/zarrjava/utils/Utils.java
@@ -77,4 +77,24 @@ public class Utils {
     }
     return result;
   }
+
+  public static boolean isPermutation(int[] array) {
+    if (array.length==0){
+      return false;
+    }
+    int[] arange = new int[array.length];
+    Arrays.setAll(arange, i -> i);
+    int[] orderSorted = array.clone();
+    Arrays.sort(orderSorted);
+    return Arrays.equals(orderSorted, arange);
+  }
+
+  public static int[] inversePermutation(int[] origin){
+    assert isPermutation(origin);
+    int[] inverse = new int[origin.length];
+    for (int i = 0; i < origin.length; i++) {
+      inverse[origin[i]] = i;
+    }
+    return inverse;
+  }
 }

--- a/src/main/java/dev/zarr/zarrjava/v3/Array.java
+++ b/src/main/java/dev/zarr/zarrjava/v3/Array.java
@@ -27,7 +27,7 @@ public class Array extends Node {
       throws IOException, ZarrException {
     super(storeHandle);
     this.metadata = arrayMetadata;
-    this.codecPipeline = new CodecPipeline(arrayMetadata.codecs);
+    this.codecPipeline = new CodecPipeline(arrayMetadata.codecs, arrayMetadata.coreArrayMetadata);
   }
 
   /**
@@ -171,8 +171,7 @@ public class Array extends Node {
 
                 if (codecPipeline.supportsPartialDecode()) {
                   final ucar.ma2.Array chunkArray = codecPipeline.decodePartial(chunkHandle,
-                      Utils.toLongArray(chunkProjection.chunkOffset), chunkProjection.shape,
-                      metadata.coreArrayMetadata);
+                      Utils.toLongArray(chunkProjection.chunkOffset), chunkProjection.shape);
                   MultiArrayUtils.copyRegion(chunkArray, new int[metadata.ndim()], outputArray,
                       chunkProjection.outOffset, chunkProjection.shape
                   );
@@ -223,7 +222,7 @@ public class Array extends Node {
       return metadata.allocateFillValueChunk();
     }
 
-    return codecPipeline.decode(chunkBytes, metadata.coreArrayMetadata);
+    return codecPipeline.decode(chunkBytes);
   }
 
   /**
@@ -299,7 +298,7 @@ public class Array extends Node {
     if (MultiArrayUtils.allValuesEqual(chunkArray, metadata.parsedFillValue)) {
       chunkHandle.delete();
     } else {
-      ByteBuffer chunkBytes = codecPipeline.encode(chunkArray, metadata.coreArrayMetadata);
+      ByteBuffer chunkBytes = codecPipeline.encode(chunkArray);
       chunkHandle.set(chunkBytes);
     }
   }

--- a/src/main/java/dev/zarr/zarrjava/v3/codec/ArrayArrayCodec.java
+++ b/src/main/java/dev/zarr/zarrjava/v3/codec/ArrayArrayCodec.java
@@ -1,15 +1,14 @@
 package dev.zarr.zarrjava.v3.codec;
 
 import dev.zarr.zarrjava.ZarrException;
-import dev.zarr.zarrjava.v3.ArrayMetadata.CoreArrayMetadata;
 import ucar.ma2.Array;
 
-public interface ArrayArrayCodec extends Codec {
+public abstract class ArrayArrayCodec extends Codec {
 
-  Array encode(Array chunkArray, CoreArrayMetadata arrayMetadata)
+  protected abstract Array encode(Array chunkArray)
       throws ZarrException;
 
-  Array decode(Array chunkArray, CoreArrayMetadata arrayMetadata)
+  protected abstract Array decode(Array chunkArray)
       throws ZarrException;
 
 }

--- a/src/main/java/dev/zarr/zarrjava/v3/codec/ArrayBytesCodec.java
+++ b/src/main/java/dev/zarr/zarrjava/v3/codec/ArrayBytesCodec.java
@@ -2,23 +2,24 @@ package dev.zarr.zarrjava.v3.codec;
 
 import dev.zarr.zarrjava.ZarrException;
 import dev.zarr.zarrjava.store.StoreHandle;
-import dev.zarr.zarrjava.v3.ArrayMetadata.CoreArrayMetadata;
 import java.nio.ByteBuffer;
 import ucar.ma2.Array;
 
-public interface ArrayBytesCodec extends Codec {
+public abstract class ArrayBytesCodec extends Codec {
 
-  ByteBuffer encode(Array chunkArray, CoreArrayMetadata arrayMetadata)
+  protected abstract ByteBuffer encode(Array chunkArray)
       throws ZarrException;
 
-  Array decode(ByteBuffer chunkBytes, CoreArrayMetadata arrayMetadata)
+  protected abstract Array decode(ByteBuffer chunkBytes)
       throws ZarrException;
 
-  interface WithPartialDecode extends ArrayBytesCodec {
+  public abstract static class WithPartialDecode extends ArrayBytesCodec {
 
-    Array decodePartial(
-        StoreHandle handle, long[] offset, int[] shape,
-        CoreArrayMetadata arrayMetadata
+    public abstract Array decode(ByteBuffer shardBytes) throws ZarrException;
+    public abstract ByteBuffer encode(Array shardArray) throws ZarrException;
+
+    protected abstract Array decodePartial(
+        StoreHandle handle, long[] offset, int[] shape
     ) throws ZarrException;
   }
 }

--- a/src/main/java/dev/zarr/zarrjava/v3/codec/BytesBytesCodec.java
+++ b/src/main/java/dev/zarr/zarrjava/v3/codec/BytesBytesCodec.java
@@ -1,15 +1,13 @@
 package dev.zarr.zarrjava.v3.codec;
 
 import dev.zarr.zarrjava.ZarrException;
-import dev.zarr.zarrjava.v3.ArrayMetadata.CoreArrayMetadata;
+
 import java.nio.ByteBuffer;
 
-public interface BytesBytesCodec extends Codec {
+public abstract class BytesBytesCodec extends Codec {
 
-  ByteBuffer encode(ByteBuffer chunkBytes, CoreArrayMetadata arrayMetadata)
-      throws ZarrException;
+    protected abstract ByteBuffer encode(ByteBuffer chunkBytes) throws ZarrException;
 
-  ByteBuffer decode(ByteBuffer chunkBytes, CoreArrayMetadata arrayMetadata)
-      throws ZarrException;
+    public abstract ByteBuffer decode(ByteBuffer chunkBytes) throws ZarrException;
 
 }

--- a/src/main/java/dev/zarr/zarrjava/v3/codec/Codec.java
+++ b/src/main/java/dev/zarr/zarrjava/v3/codec/Codec.java
@@ -5,9 +5,22 @@ import dev.zarr.zarrjava.ZarrException;
 import dev.zarr.zarrjava.v3.ArrayMetadata;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "name")
-public interface Codec {
+public abstract class Codec {
 
-  long computeEncodedSize(long inputByteLength, ArrayMetadata.CoreArrayMetadata arrayMetadata)
-      throws ZarrException;
+    protected ArrayMetadata.CoreArrayMetadata arrayMetadata;
+
+    protected ArrayMetadata.CoreArrayMetadata resolveArrayMetadata() throws ZarrException {
+        if (arrayMetadata == null) {
+            throw new ZarrException("arrayMetadata needs to get set in for every codec");
+        }
+        return this.arrayMetadata;
+    }
+
+    protected abstract long computeEncodedSize(long inputByteLength, ArrayMetadata.CoreArrayMetadata arrayMetadata)
+            throws ZarrException;
+
+    public void setCoreArrayMetadata(ArrayMetadata.CoreArrayMetadata arrayMetadata) throws ZarrException{
+        this.arrayMetadata = arrayMetadata;
+    }
 }
 

--- a/src/main/java/dev/zarr/zarrjava/v3/codec/CodecBuilder.java
+++ b/src/main/java/dev/zarr/zarrjava/v3/codec/CodecBuilder.java
@@ -62,13 +62,9 @@ public class CodecBuilder {
     return withBlosc("zstd");
   }
 
-  public CodecBuilder withTranspose(String order) {
-    try {
+  public CodecBuilder withTranspose(int[] order) {
       codecs.add(new TransposeCodec(new TransposeCodec.Configuration(order)));
-    } catch (ZarrException e) {
-      throw new RuntimeException(e);
-    }
-    return this;
+      return this;
   }
 
   public CodecBuilder withBytes(Endian endian) {

--- a/src/main/java/dev/zarr/zarrjava/v3/codec/core/BloscCodec.java
+++ b/src/main/java/dev/zarr/zarrjava/v3/codec/core/BloscCodec.java
@@ -20,7 +20,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import javax.annotation.Nonnull;
 
-public class BloscCodec implements BytesBytesCodec {
+public class BloscCodec extends BytesBytesCodec {
 
   public final String name = "blosc";
   @Nonnull
@@ -33,7 +33,7 @@ public class BloscCodec implements BytesBytesCodec {
   }
 
   @Override
-  public ByteBuffer decode(ByteBuffer chunkBytes, ArrayMetadata.CoreArrayMetadata arrayMetadata)
+  public ByteBuffer decode(ByteBuffer chunkBytes)
       throws ZarrException {
     try {
       return ByteBuffer.wrap(Blosc.decompress(Utils.toArray(chunkBytes)));
@@ -43,7 +43,7 @@ public class BloscCodec implements BytesBytesCodec {
   }
 
   @Override
-  public ByteBuffer encode(ByteBuffer chunkBytes, ArrayMetadata.CoreArrayMetadata arrayMetadata)
+  public ByteBuffer encode(ByteBuffer chunkBytes)
       throws ZarrException {
     try {
       return ByteBuffer.wrap(

--- a/src/main/java/dev/zarr/zarrjava/v3/codec/core/BytesCodec.java
+++ b/src/main/java/dev/zarr/zarrjava/v3/codec/core/BytesCodec.java
@@ -11,7 +11,7 @@ import java.nio.ByteOrder;
 import javax.annotation.Nonnull;
 import ucar.ma2.Array;
 
-public class BytesCodec implements ArrayBytesCodec {
+public class BytesCodec extends ArrayBytesCodec {
 
   public final String name = "bytes";
   @Nonnull
@@ -29,14 +29,14 @@ public class BytesCodec implements ArrayBytesCodec {
   }
 
   @Override
-  public Array decode(ByteBuffer chunkBytes, ArrayMetadata.CoreArrayMetadata arrayMetadata) {
+  public Array decode(ByteBuffer chunkBytes) {
     chunkBytes.order(configuration.endian.getByteOrder());
     return Array.factory(arrayMetadata.dataType.getMA2DataType(), arrayMetadata.chunkShape,
         chunkBytes);
   }
 
   @Override
-  public ByteBuffer encode(Array chunkArray, ArrayMetadata.CoreArrayMetadata arrayMetadata) {
+  public ByteBuffer encode(Array chunkArray) {
     return chunkArray.getDataAsByteBuffer(configuration.endian.getByteOrder());
   }
 
@@ -72,7 +72,7 @@ public class BytesCodec implements ArrayBytesCodec {
     }
   }
 
-  public static final class Configuration {
+  public static final class Configuration{
 
     @Nonnull
     public final BytesCodec.Endian endian;

--- a/src/main/java/dev/zarr/zarrjava/v3/codec/core/Crc32cCodec.java
+++ b/src/main/java/dev/zarr/zarrjava/v3/codec/core/Crc32cCodec.java
@@ -9,17 +9,15 @@ import dev.zarr.zarrjava.v3.ArrayMetadata.CoreArrayMetadata;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
-public class Crc32cCodec implements BytesBytesCodec {
+public class Crc32cCodec extends BytesBytesCodec {
 
   public final String name = "crc32c";
 
   @JsonCreator
-  public Crc32cCodec(
-  ) {
-  }
+  public Crc32cCodec(){}
 
   @Override
-  public ByteBuffer decode(ByteBuffer chunkBytes, CoreArrayMetadata arrayMetadata)
+  public ByteBuffer decode(ByteBuffer chunkBytes)
       throws ZarrException {
     ByteBuffer buffer = chunkBytes.slice();
     buffer.order(ByteOrder.LITTLE_ENDIAN);
@@ -45,7 +43,7 @@ public class Crc32cCodec implements BytesBytesCodec {
   }
 
   @Override
-  public ByteBuffer encode(ByteBuffer chunkBytes, CoreArrayMetadata arrayMetadata) {
+  public ByteBuffer encode(ByteBuffer chunkBytes) {
     return Utils.makeByteBuffer(chunkBytes.capacity() + 4, b -> {
       final CRC32C crc32c = new CRC32C();
       crc32c.update(chunkBytes);

--- a/src/main/java/dev/zarr/zarrjava/v3/codec/core/GzipCodec.java
+++ b/src/main/java/dev/zarr/zarrjava/v3/codec/core/GzipCodec.java
@@ -16,7 +16,7 @@ import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 import javax.annotation.Nonnull;
 
-public class GzipCodec implements BytesBytesCodec {
+public class GzipCodec extends BytesBytesCodec {
 
   public final String name = "gzip";
   @Nonnull
@@ -37,7 +37,7 @@ public class GzipCodec implements BytesBytesCodec {
   }
 
   @Override
-  public ByteBuffer decode(ByteBuffer chunkBytes, ArrayMetadata.CoreArrayMetadata arrayMetadata)
+  public ByteBuffer decode(ByteBuffer chunkBytes)
       throws ZarrException {
     try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream(); GZIPInputStream inputStream = new GZIPInputStream(
         new ByteArrayInputStream(Utils.toArray(chunkBytes)))) {
@@ -50,7 +50,7 @@ public class GzipCodec implements BytesBytesCodec {
   }
 
   @Override
-  public ByteBuffer encode(ByteBuffer chunkBytes, ArrayMetadata.CoreArrayMetadata arrayMetadata)
+  public ByteBuffer encode(ByteBuffer chunkBytes)
       throws ZarrException {
     try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream(); GZIPOutputStream gzipStream = new GZIPOutputStream(
         outputStream)) {

--- a/src/main/java/dev/zarr/zarrjava/v3/codec/core/TransposeCodec.java
+++ b/src/main/java/dev/zarr/zarrjava/v3/codec/core/TransposeCodec.java
@@ -5,62 +5,87 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import dev.zarr.zarrjava.ZarrException;
 import dev.zarr.zarrjava.v3.ArrayMetadata;
 import dev.zarr.zarrjava.v3.codec.ArrayArrayCodec;
-import javax.annotation.Nonnull;
 import ucar.ma2.Array;
 
-public class TransposeCodec implements ArrayArrayCodec {
+import javax.annotation.Nonnull;
+import java.util.Arrays;
 
-  @Nonnull
-  public final String name = "transpose";
-  @Nonnull
-  public final Configuration configuration;
+import static dev.zarr.zarrjava.utils.Utils.inversePermutation;
+import static dev.zarr.zarrjava.utils.Utils.isPermutation;
 
-  @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
-  public TransposeCodec(
-      @Nonnull @JsonProperty(value = "configuration", required = true) Configuration configuration
-  ) {
-    this.configuration = configuration;
-  }
+public class TransposeCodec extends ArrayArrayCodec {
 
-  int[] reverseDims(int ndim) {
-    int[] dims = new int[ndim];
-    for (int dimIdx = 0; dimIdx < ndim; dimIdx++) {
-      dims[dimIdx] = ndim - dimIdx - 1;
-    }
-    return dims;
-  }
-
-  @Override
-  public Array decode(Array chunkArray, ArrayMetadata.CoreArrayMetadata arrayMetadata) {
-    if (configuration.order.equals("F")) {
-      chunkArray.permute(reverseDims(arrayMetadata.ndim()));
-    }
-    return chunkArray;
-  }
-
-  @Override
-  public Array encode(Array chunkArray, ArrayMetadata.CoreArrayMetadata arrayMetadata) {
-    if (configuration.order.equals("F")) {
-      chunkArray.permute(reverseDims(arrayMetadata.ndim()));
-    }
-    return chunkArray;
-  }
-
-  @Override
-  public long computeEncodedSize(long inputByteLength,
-      ArrayMetadata.CoreArrayMetadata arrayMetadata) throws ZarrException {
-    return inputByteLength;
-  }
-
-  public static final class Configuration {
-
-    // TODO: order 'C' and 'F' are deprecated
-    // https://zarr-specs.readthedocs.io/en/latest/v3/codecs/transpose/v1.0.html#transpose-codec-v1
-    public final int[] order;
+    @Nonnull
+    public final String name = "transpose";
+    @Nonnull
+    public final Configuration configuration;
 
     @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
-    public Configuration(@JsonProperty(value = "order") int[] order){
-      this.order = order;
+    public TransposeCodec(
+            @Nonnull @JsonProperty(value = "configuration", required = true) Configuration configuration
+    ) {
+        this.configuration = configuration;
     }
-  }
+
+
+    @Override
+    public Array decode(Array chunkArray) throws ZarrException {
+        if (!isPermutation(configuration.order)){
+            throw new ZarrException("Order is no permutation array");
+        }
+        if (arrayMetadata.ndim() != configuration.order.length) {
+            throw new ZarrException("Array has not the same ndim as transpose codec order");
+        }
+        chunkArray = chunkArray.permute(inversePermutation(configuration.order));
+        return chunkArray;
+    }
+
+
+
+    @Override
+    public Array encode(Array chunkArray) throws ZarrException {
+        if (!isPermutation(configuration.order)){
+            throw new ZarrException("Order is no permutation array");
+        }
+        if (arrayMetadata.ndim() != configuration.order.length) {
+            throw new ZarrException("Array has not the same ndim as transpose codec order");
+        }
+        chunkArray = chunkArray.permute(configuration.order);
+        return chunkArray;
+    }
+
+    @Override
+    public long computeEncodedSize(long inputByteLength,
+                                   ArrayMetadata.CoreArrayMetadata arrayMetadata) throws ZarrException {
+        return inputByteLength;
+    }
+
+    public static final class Configuration {
+        public final int[] order;
+
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+        public Configuration(@JsonProperty(value = "order") int[] order) {
+            this.order = order;
+        }
+    }
+
+    @Override
+    protected ArrayMetadata.CoreArrayMetadata resolveArrayMetadata() throws ZarrException {
+        super.resolveArrayMetadata();
+        assert arrayMetadata.ndim() == configuration.order.length;
+
+        int[] transposedChunkShape = new int[arrayMetadata.ndim()];
+        Arrays.setAll(transposedChunkShape, i -> arrayMetadata.chunkShape[configuration.order[i]]);
+
+        //only chunk shape gets transformed, the outer shape stays the same
+        long[] transposedArrayShape = new long[arrayMetadata.ndim()];
+        Arrays.setAll(transposedArrayShape, i -> arrayMetadata.shape[i]/arrayMetadata.chunkShape[i]*transposedArrayShape[i]);
+
+        return new ArrayMetadata.CoreArrayMetadata(
+                transposedArrayShape,
+                transposedChunkShape,
+                arrayMetadata.dataType,
+                arrayMetadata.parsedFillValue
+        );
+    }
 }

--- a/src/main/java/dev/zarr/zarrjava/v3/codec/core/TransposeCodec.java
+++ b/src/main/java/dev/zarr/zarrjava/v3/codec/core/TransposeCodec.java
@@ -56,14 +56,10 @@ public class TransposeCodec implements ArrayArrayCodec {
 
     // TODO: order 'C' and 'F' are deprecated
     // https://zarr-specs.readthedocs.io/en/latest/v3/codecs/transpose/v1.0.html#transpose-codec-v1
-    public final String order;
+    public final int[] order;
 
     @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
-    public Configuration(@JsonProperty(value = "order", defaultValue = "C") String order)
-        throws ZarrException {
-      if (!order.equals("C") && !order.equals("F")) {
-        throw new ZarrException("Only 'C' or 'F' are supported.");
-      }
+    public Configuration(@JsonProperty(value = "order") int[] order){
       this.order = order;
     }
   }

--- a/src/main/java/dev/zarr/zarrjava/v3/codec/core/TransposeCodec.java
+++ b/src/main/java/dev/zarr/zarrjava/v3/codec/core/TransposeCodec.java
@@ -54,6 +54,8 @@ public class TransposeCodec implements ArrayArrayCodec {
 
   public static final class Configuration {
 
+    // TODO: order 'C' and 'F' are deprecated
+    // https://zarr-specs.readthedocs.io/en/latest/v3/codecs/transpose/v1.0.html#transpose-codec-v1
     public final String order;
 
     @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)

--- a/src/main/java/dev/zarr/zarrjava/v3/codec/core/ZstdCodec.java
+++ b/src/main/java/dev/zarr/zarrjava/v3/codec/core/ZstdCodec.java
@@ -16,7 +16,7 @@ import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import javax.annotation.Nonnull;
 
-public class ZstdCodec implements BytesBytesCodec {
+public class ZstdCodec extends BytesBytesCodec {
 
   public final String name = "zstd";
   @Nonnull
@@ -37,7 +37,7 @@ public class ZstdCodec implements BytesBytesCodec {
   }
 
   @Override
-  public ByteBuffer decode(ByteBuffer chunkBytes, ArrayMetadata.CoreArrayMetadata arrayMetadata)
+  public ByteBuffer decode(ByteBuffer chunkBytes)
       throws ZarrException {
     try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream(); ZstdInputStream inputStream = new ZstdInputStream(
         new ByteArrayInputStream(Utils.toArray(chunkBytes)))) {
@@ -50,7 +50,7 @@ public class ZstdCodec implements BytesBytesCodec {
   }
 
   @Override
-  public ByteBuffer encode(ByteBuffer chunkBytes, ArrayMetadata.CoreArrayMetadata arrayMetadata)
+  public ByteBuffer encode(ByteBuffer chunkBytes)
       throws ZarrException {
     try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream(); ZstdOutputStream zstdStream = new ZstdOutputStream(
         outputStream, configuration.level).setChecksum(

--- a/src/test/java/dev/zarr/zarrjava/TestUtils.java
+++ b/src/test/java/dev/zarr/zarrjava/TestUtils.java
@@ -1,0 +1,31 @@
+package dev.zarr.zarrjava;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static dev.zarr.zarrjava.utils.Utils.inversePermutation;
+import static dev.zarr.zarrjava.utils.Utils.isPermutation;
+import static org.junit.Assert.assertFalse;
+
+public class TestUtils {
+    @Test
+    public void testIsPermutation(){
+        assert isPermutation(new int[]{2, 1, 0});
+        assert isPermutation(new int[]{4, 2, 1, 3, 0});
+        assert !isPermutation(new int[]{0, 1, 2, 0});
+        assert !isPermutation(new int[]{0, 1, 2, 3, 5});
+        assert !isPermutation(new int[]{});
+    }
+
+    @Test
+    public void testInversePermutation(){
+        Assertions.assertArrayEquals(new int[]{1, 0, 2}, inversePermutation(new int[]{1, 0, 2}));
+        Assertions.assertArrayEquals(new int[]{2, 0, 1}, inversePermutation(new int[]{1, 2, 0}));
+        Assertions.assertArrayEquals(new int[]{0, 3, 2, 4, 1}, inversePermutation(new int[]{0, 4, 2, 1, 3}));
+        Assertions.assertFalse(Arrays.equals(new int[]{2, 0, 1}, inversePermutation(new int[]{2, 0, 1})));
+    }
+
+}
+

--- a/src/test/java/dev/zarr/zarrjava/ZarrTest.java
+++ b/src/test/java/dev/zarr/zarrjava/ZarrTest.java
@@ -155,7 +155,7 @@ public class ZarrTest {
                 builder = builder.withCodecs(c -> c.withBytes("LITTLE"));
                 break;
             case "transpose":
-                builder = builder.withCodecs(c -> c.withTranspose("F"));
+                builder = builder.withCodecs(c -> c.withTranspose(new int[]{1, 0}));
                 break;
             case "sharding":
                 builder = builder.withCodecs(c -> c.withSharding(new int[]{4, 4}, c1 -> c1.withBytes("LITTLE")));
@@ -223,7 +223,7 @@ public class ZarrTest {
                 builder = builder.withCodecs(c -> c.withBytes("LITTLE"));
                 break;
             case "transpose":
-                builder = builder.withCodecs(c -> c.withTranspose("F"));
+                builder = builder.withCodecs(c -> c.withTranspose(new int[]{1, 0, 2}));
                 break;
             case "sharding":
                 builder = builder.withCodecs(c -> c.withSharding(new int[]{2, 2, 4}, c1 -> c1.withBytes("LITTLE")));
@@ -253,7 +253,7 @@ public class ZarrTest {
     public void testCodecTranspose() throws IOException, ZarrException, InterruptedException {
         ucar.ma2.Array testData = ucar.ma2.Array.factory(ucar.ma2.DataType.UINT, new int[]{2, 3, 3}, new int[]{
                 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17});
-        ucar.ma2.Array testDataTransposed120 = ucar.ma2.Array.factory(ucar.ma2.DataType.UINT, new int[]{2, 3, 3}, new int[]{
+        ucar.ma2.Array testDataTransposed120 = ucar.ma2.Array.factory(ucar.ma2.DataType.UINT, new int[]{3, 3, 2}, new int[]{
                 0, 9, 1, 10, 2, 11, 3, 12, 4, 13, 5, 14, 6, 15, 7, 16, 8, 17});
 
         ArrayMetadata.CoreArrayMetadata metadata = new ArrayMetadata.CoreArrayMetadata(
@@ -265,12 +265,16 @@ public class ZarrTest {
         TransposeCodec transposeCodecWrongOrder1 = new TransposeCodec(new TransposeCodec.Configuration(new int[]{1, 2, 2}));
         TransposeCodec transposeCodecWrongOrder2 = new TransposeCodec(new TransposeCodec.Configuration(new int[]{1, 2, 3}));
         TransposeCodec transposeCodecWrongOrder3 = new TransposeCodec(new TransposeCodec.Configuration(new int[]{1, 2, 3, 0}));
+        transposeCodec.setCoreArrayMetadata(metadata);
+        transposeCodecWrongOrder1.setCoreArrayMetadata(metadata);
+        transposeCodecWrongOrder2.setCoreArrayMetadata(metadata);
+        transposeCodecWrongOrder3.setCoreArrayMetadata(metadata);
 
-        assertEquals(testDataTransposed120, transposeCodec.encode(testData, metadata));
-        assertEquals(testData, transposeCodec.decode(testDataTransposed120, metadata));
-        assertThrows(ZarrException.class, () -> transposeCodecWrongOrder1.encode(testData, metadata));
-        assertThrows(ZarrException.class, () -> transposeCodecWrongOrder2.encode(testData, metadata));
-        assertThrows(ZarrException.class, () -> transposeCodecWrongOrder3.encode(testData, metadata));
+        assert ucar.ma2.MAMath.equals(testDataTransposed120, transposeCodec.encode(testData));
+        assert ucar.ma2.MAMath.equals(testData, transposeCodec.decode(testDataTransposed120));
+        assertThrows(ZarrException.class, () -> transposeCodecWrongOrder1.encode(testData));
+        assertThrows(ZarrException.class, () -> transposeCodecWrongOrder2.encode(testData));
+        assertThrows(ZarrException.class, () -> transposeCodecWrongOrder3.encode(testData));
     }
 
     @Test

--- a/src/test/java/dev/zarr/zarrjava/ZarrTest.java
+++ b/src/test/java/dev/zarr/zarrjava/ZarrTest.java
@@ -10,10 +10,8 @@ import dev.zarr.zarrjava.store.S3Store;
 import dev.zarr.zarrjava.store.StoreHandle;
 import dev.zarr.zarrjava.utils.MultiArrayUtils;
 import dev.zarr.zarrjava.v3.*;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
+import dev.zarr.zarrjava.v3.codec.core.TransposeCodec;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -36,12 +34,12 @@ public class ZarrTest {
 
     final static Path TESTDATA = Paths.get("testdata");
     final static Path TESTOUTPUT = Paths.get("testoutput");
-
     //TODO: is the Path with / instead of \ readable in Windows?
     final static Path ZARRITA_WRITE_PATH = Paths.get("src/test/java/dev/zarr/zarrjava/zarrita_write.py");
     final static Path ZARRITA_READ_PATH = Paths.get("src/test/java/dev/zarr/zarrjava/zarrita_read.py");
-
     final static String CONDA_ENVIRONMENT = "zarrita_env";
+    static ucar.ma2.Array testData;
+    static ucar.ma2.Array testDataTransposed;
 
     @BeforeAll
     public static void clearTestoutputFolder() throws IOException {
@@ -94,6 +92,52 @@ public class ZarrTest {
                 System.err.println(s);
             }
         }
+    }
+
+    @BeforeEach
+    public void fillTestData() {
+        testData = ucar.ma2.Array.factory(ucar.ma2.DataType.UINT, new int[]{4, 4, 4}, new int[]{
+                0, 1, 2, 3,
+                4, 5, 6, 7,
+                8, 9, 10, 11,
+                12, 13, 14, 15,
+
+                16, 17, 18, 19,
+                20, 21, 22, 23,
+                24, 25, 26, 27,
+                28, 29, 30, 31,
+
+                32, 33, 34, 35,
+                36, 37, 38, 39,
+                40, 41, 42, 43,
+                44, 45, 46, 47,
+
+                48, 49, 50, 51,
+                52, 53, 54, 55,
+                56, 57, 58, 59,
+                60, 61, 62, 63
+        });
+        testDataTransposed = ucar.ma2.Array.factory(ucar.ma2.DataType.UINT, new int[]{4, 4, 4}, new int[]{
+                0, 16, 32, 48,
+                4, 20, 36, 52,
+                8, 24, 40, 56,
+                12, 28, 44, 60,
+
+                1, 17, 33, 49,
+                5, 21, 37, 53,
+                9, 25, 41, 57,
+                13, 29, 45, 61,
+
+                2, 18, 34, 50,
+                6, 22, 38, 54,
+                10, 26, 42, 58,
+                14, 30, 46, 62,
+
+                3, 19, 35, 51,
+                7, 23, 39, 55,
+                11, 27, 43, 59,
+                15, 31, 47, 63
+        });
     }
 
     @ParameterizedTest
@@ -249,6 +293,21 @@ public class ZarrTest {
         Assertions.assertEquals("test_value", readArray.metadata.attributes.get("test_key"));
 
         Assertions.assertArrayEquals(testData, (int[]) result.get1DJavaArray(ucar.ma2.DataType.INT));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"F", "C"})
+    public void testCodecTranspose(String order) throws IOException, ZarrException, InterruptedException {
+        ArrayMetadata.CoreArrayMetadata metadata = new ArrayMetadata.CoreArrayMetadata(
+                new long[]{4, 4, 4},
+                new int[]{4, 4, 4},
+                DataType.UINT32,
+                null);
+        TransposeCodec transposeCodec = new TransposeCodec(new TransposeCodec.Configuration(order));
+
+        //TODO is that what is expected?
+        assertEquals(testDataTransposed, transposeCodec.encode(testData, metadata));
+        assertEquals(testData, transposeCodec.decode(testDataTransposed, metadata));
     }
 
     @Test

--- a/src/test/java/dev/zarr/zarrjava/zarrita_read.py
+++ b/src/test/java/dev/zarr/zarrjava/zarrita_read.py
@@ -14,7 +14,7 @@ elif codec_string == "zstd":
 elif codec_string == "bytes":
     codec = [zarrita.codecs.bytes_codec()]
 elif codec_string == "transpose":
-    codec = [zarrita.codecs.transpose_codec("F"), zarrita.codecs.bytes_codec()]
+    codec = [zarrita.codecs.transpose_codec((1, 0)), zarrita.codecs.bytes_codec()]
 elif codec_string == "sharding":
     codec= zarrita.codecs.sharding_codec(chunk_shape=(4, 4), codecs=[zarrita.codecs.bytes_codec("little")]),
 elif codec_string == "crc32c":

--- a/src/test/java/dev/zarr/zarrjava/zarrita_write.py
+++ b/src/test/java/dev/zarr/zarrjava/zarrita_write.py
@@ -14,7 +14,7 @@ elif codec_string == "zstd":
 elif codec_string == "bytes":
     codec = [zarrita.codecs.bytes_codec()]
 elif codec_string == "transpose":
-    codec = [zarrita.codecs.transpose_codec("F"), zarrita.codecs.bytes_codec()]
+    codec = [zarrita.codecs.transpose_codec([0, 1]), zarrita.codecs.bytes_codec()]
 elif codec_string == "sharding":
     codec = [zarrita.codecs.sharding_codec(chunk_shape=(1, 2), codecs=[zarrita.codecs.bytes_codec()])]
 elif codec_string == "crc32c":


### PR DESCRIPTION
should fix broken data when reading array with transpose codec https://zarr-specs.readthedocs.io/en/latest/v3/codecs/transpose/v1.0.html
Also, the argument `order` now should only support int arrays.